### PR TITLE
Fix #13: Security: Interne Fehlermeldungen werden in HTTP 500 Responses an Clients zurueckgegeben

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -77,7 +77,10 @@ app.include_router(tickets_router, prefix=API_PREFIX)
 async def global_exception_handler(request: Request, exc: Exception):
     tb = traceback.format_exception(type(exc), exc, exc.__traceback__)
     logging.getLogger(__name__).error("Unhandled error: %s\n%s", exc, "".join(tb))
-    return JSONResponse(status_code=500, content={"detail": str(exc)})
+    return JSONResponse(
+        status_code=500,
+        content={"detail": "Interner Serverfehler. Bitte Administrator kontaktieren."},
+    )
 
 
 @app.get("/api/health")

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -1,0 +1,37 @@
+"""Tests fuer den globalen Exception-Handler in main.py."""
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from app.main import app
+
+
+@pytest.mark.asyncio
+async def test_global_exception_handler_gibt_keine_internen_details_zurueck():
+    """HTTP-500-Antworten dürfen keine internen Fehlermeldungen enthalten."""
+
+    # Hilfroute, die absichtlich eine Exception wirft
+    test_app = FastAPI()
+
+    @test_app.get("/trigger-error")
+    async def trigger_error():
+        raise RuntimeError("Geheimer Datenbankfehler: SELECT * FROM users WHERE password='secret'")
+
+    # Den globalen Exception-Handler aus main.py registrieren
+    from app.main import global_exception_handler
+    test_app.add_exception_handler(Exception, global_exception_handler)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=test_app), base_url="http://test"
+    ) as client:
+        response = await client.get("/trigger-error")
+
+    assert response.status_code == 500
+    body = response.json()
+    # Generische Meldung muss vorhanden sein
+    assert body["detail"] == "Interner Serverfehler. Bitte Administrator kontaktieren."
+    # Interne Fehlerdetails dürfen nicht zurückgegeben werden
+    assert "Geheimer" not in body["detail"]
+    assert "SELECT" not in body["detail"]
+    assert "secret" not in body["detail"]


### PR DESCRIPTION
Automatisch erstellt vom Entwickler-Agent.

Behebt #13

Bitte reviewen und mergen.